### PR TITLE
Automate building/publishing of the website

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,66 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements. See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License. You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Publish Daffodil Site
+
+on: [push]
+
+jobs:
+  test:
+    name: Publish Site
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+    steps:
+
+      - name: Checkout Repository
+        uses: actions/checkout@v1.0.0
+
+      - name: Install Ruby
+        uses: actions/setup-ruby@v1
+        with:
+          ruby-version: '2.6'
+
+      - name: Install Python
+        uses: actions/setup-python@v1
+        with:
+          python-version: '3.5'
+
+      - name: Install Dependencies
+        run: |
+          sudo apt-get install graphviz
+          bundle install
+          python -m pip install --upgrade pip
+          pip install blockdiag
+          pip install seqdiag
+          pip install actdiag
+          pip install nwdiag
+
+      - name: Build 
+        run: |
+          jekyll clean --source site
+          jekyll build --source site
+
+      - name: Publish
+        if: github.repository == 'apache/incubator-daffodil-site'
+        run: |
+          git checkout asf-site
+          rm -rf content
+          mv target content
+          git add content
+          git config --local user.email "${{ github.event.head_commit.committer.email }}"
+          git config --local user.name "${{ github.event.head_commit.committer.name }}"
+          git commit -a --allow-empty -m "Publishing from ${{ github.sha }}"
+          git push --force "https://${{ github.actor }}:${{ github.token }}@github.com/${{ github.repository }}.git" asf-site

--- a/Gemfile
+++ b/Gemfile
@@ -1,39 +1,21 @@
-#!/usr/bin/env bash
-#
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.
 # The ASF licenses this file to you under the Apache License, Version 2.0
 # (the "License"); you may not use this file except in compliance with
 # the License.  You may obtain a copy of the License at
-#
+# 
 # http://www.apache.org/licenses/LICENSE-2.0
-#
+# 
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-#
 
-set -e
+source 'https://rubygems.org'
 
-jekyll clean --source site
-jekyll build --source site
+gem 'jekyll', '= 4.0.0'
+gem 'jekyll-asciidoc', '= 3.0.0'
+gem 'asciidoctor-diagram', '= 2.0.1'
 
-COMMIT_HASH=`git rev-parse HEAD`
-git checkout asf-site
-#git pull --rebase
-rm -rf content
-mv target content
-git add content
-echo "Publishing changes from master branch $COMMIT_HASH"
-git commit -a -m "Publishing from $COMMIT_HASH"
-echo " "
-echo "==================================================================="
-echo "You are now on the asf-site branch with your new changes committed."
-echo " git push the 'asf-site' branch upstream to update the live site."
-echo "==================================================================="
-echo " "
-
-set +e

--- a/README.md
+++ b/README.md
@@ -25,15 +25,19 @@ The website is generated using [Jekyll](https://jekyllrb.com/) and some plug-ins
 
 # How to deploy this web site
 
-## Install Jekyll
+## Install Ruby Bundler
 
-Some Linux distributions provide Jekyll via their package managers, for example, for Fedora 25
+Some Linux distributions provide the Ruby Bundler via their package managers, for example, for Fedora:
 
-    $ dnf install rubygem-jekyll
+    $ dnf install rubygem-bundler
 
-Alternatively, Jekyll can be installed using gem:
+## Install or Update Site Dependencies
 
-    $ gem install jekyll
+    $ gem install
+
+or
+
+    $ gem update
 
 ## Install Jekyll Plug-ins for AsciiDoc and Diagram Rendering
 
@@ -42,8 +46,6 @@ embedded diagrams created from diagram-specifying text formats.
 
 (You probably want to install these as super-user using sudo.)
 
-    $ gem install jekyll-asciidoc
-    $ gem install asciidoctor-diagram
     $ apt install python-pip
     $ pip install blockdiag
     $ pip install seqdiag
@@ -52,7 +54,7 @@ embedded diagrams created from diagram-specifying text formats.
 
 NOTE: `nwdiag` actually supports more than one diagram type. It supports nwdiag, packetdiag, rackdiag, etc.
 
-## Running locally
+## Running Locally
 
 Before opening a pull request, you can preview your contributions by
 running from within the directory:
@@ -65,12 +67,10 @@ Once satisfied, create a branch and open a pull request using the Daffodil
 project [Code Conttributor Workflow](https://cwiki.apache.org/confluence/display/DAFFODIL/Code+Contributor+Workflow)
 but using the website repo instead of the code repo.
 
-## Pushing to the live site
+## Pushing to the Live Site
 
 Daffodil uses [gitpubsub](https://www.apache.org/dev/gitpubsub.html) for
 publishing to the website. The static content served via apache must be served
-in the ``content`` directory on the ``asf-site`` orphan branch. Use the
-``publish.sh`` script script exists to create this content:
-
-    $ ./publish.sh
-    $ git push asf asf-site
+in the ``content`` directory on the ``asf-site`` orphan branch. When the changes
+are merged into the master branch on GitHub, a GitHub action will automatically
+be triggered and it will perform the necessary steps to publish the site.


### PR DESCRIPTION
Creating the website can be completely automated, and can be done in a
way that avoids environmental differences between developers systems.
This configured a github action to automatically build and publish the
github website everytime the master branch is update. A Gem file is used
to define dependencies and ensure consistency. The publish.sh script is
no longer needed, so it is deleted.