### PR TITLE
Redirect releases/ to libraryAndCLI/

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,6 +17,7 @@ source 'https://rubygems.org'
 
 gem 'jekyll', '= 4.2.2'
 gem 'jekyll-asciidoc', '= 3.0.1'
+gem 'jekyll-redirect-from', '= 0.16.0'
 gem 'asciidoctor-diagram', '= 3.0.0'
 gem 'asciidoctor-diagram-plantuml', '= 1.2025.2'
 gem 'asciidoctor-diagram-ditaamini', '= 1.0.3'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -41,6 +41,8 @@ GEM
     jekyll-asciidoc (3.0.1)
       asciidoctor (>= 1.5.0, < 3.0.0)
       jekyll (>= 3.0.0)
+    jekyll-redirect-from (0.16.0)
+      jekyll (>= 3.3, < 5.0)
     jekyll-sass-converter (2.2.0)
       sassc (> 2.0.1, < 3.0)
     jekyll-watch (2.2.1)
@@ -80,6 +82,7 @@ DEPENDENCIES
   asciidoctor-diagram-plantuml (= 1.2025.2)
   jekyll (= 4.2.2)
   jekyll-asciidoc (= 3.0.1)
+  jekyll-redirect-from (= 0.16.0)
   webrick (= 1.9.1)
 
 BUNDLED WITH

--- a/site/_config.yml
+++ b/site/_config.yml
@@ -45,9 +45,10 @@ defaults:
 jira_base_url: https://issues.apache.org/jira/browse
 jira_key: DAFFODIL
 
-# plugin for asciidoc (.adoc) files
+# plugins
 plugins:
 - jekyll-asciidoc
+- jekyll-redirect-from
 - asciidoctor-diagram
 
 keep_files:

--- a/site/libraryAndCLI.md
+++ b/site/libraryAndCLI.md
@@ -2,6 +2,7 @@
 layout: page
 title: Daffodil Library and CLI
 group: nav-right
+redirect_from: /releases/
 ---
 <!--
 {% comment %}


### PR DESCRIPTION
Commit 4831a9ff0b renamed the releases.md file to libraryAndCLI.md to identify the subprojects. However, some places might still reference the old releases/ URL, which currently shows a directory listing and is not particularly user friendly.

This adds the jekeyll-redirect-from plugin and adds the redirect_from setting to the libraryAndCLI page to auto redirect to old URL to the new one.